### PR TITLE
add entries() and values() to RedisMapCache

### DIFF
--- a/src/helpers/resolve-redis-instance.test.ts
+++ b/src/helpers/resolve-redis-instance.test.ts
@@ -1,0 +1,12 @@
+import { resolveRedisInstance } from "./resolve-redis-instance";
+import Redis from "ioredis";
+import RedisMock from "ioredis-mock";
+
+class Test extends Redis {}
+
+it("should take a redis connection URI", () => {
+  expect(resolveRedisInstance({ lazyConnect: true })).toBeInstanceOf(Redis);
+  expect(resolveRedisInstance(new RedisMock())).toBeInstanceOf(RedisMock);
+  expect(resolveRedisInstance("redis://localhost:6379", { lazyConnect: true })).toBeInstanceOf(Redis);
+  expect(resolveRedisInstance(new Test({ lazyConnect: true }))).toBeInstanceOf(Test);
+});

--- a/src/redis/map.redis.test.ts
+++ b/src/redis/map.redis.test.ts
@@ -10,6 +10,15 @@ beforeEach(() => {
   client = new MockRedis();
 });
 
+async function getGeneratorValues<T>(generator: AsyncGenerator<T, any, any>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of generator) {
+    values.push(value);
+  }
+
+  return values;
+}
+
 describe("RedisMapCache", () => {
   it("Should cache data for 2 seconds", async () => {
     const cache = new RedisMapCache<string>(client, "fortnite", { defaultExpiry: 50 });
@@ -50,13 +59,65 @@ describe("RedisMapCache", () => {
 
   it('should return a list of keys from the "keys" method', async () => {
     const cache = new RedisMapCache<string>(client, "fortnite", { trackKeys: true });
+
     await cache.set("test1", "epic");
     expect(await cache.keys()).toEqual(["test1"]);
     await cache.set("test2", "epic");
     expect(await cache.keys()).toEqual(["test1", "test2"]);
+
+    // deleting keys should remove them from the result
     await cache.delete("test1");
     expect(await cache.keys()).toEqual(["test2"]);
+
+    // clearing everything should also clear the set
     await cache.clear();
     expect(await cache.keys()).toEqual([]);
+  });
+
+  it("should handle getting all entries in the cache", async () => {
+    const cache = new RedisMapCache<string>(client, "fortnite", { trackKeys: true });
+
+    await cache.set("test1", "epic1");
+    await cache.set("test2", "epic2");
+    expect(await cache.keys()).toEqual(["test1", "test2"]);
+    expect(await getGeneratorValues(cache.entries())).toEqual([
+      ["test1", "epic1"],
+      ["test2", "epic2"],
+    ]);
+
+    // deleting keys should remove them from the result
+    await cache.delete("test1");
+    expect(await getGeneratorValues(cache.entries())).toEqual([["test2", "epic2"]]);
+
+    // clearing everything should mean an empty result
+    await cache.clear();
+    expect(await getGeneratorValues(cache.entries())).toEqual([]);
+  });
+
+  it("should handle getting all values in the cache", async () => {
+    const cache = new RedisMapCache<string>(client, "fortnite", { trackKeys: true });
+
+    await cache.set("test1", "epic1");
+    await cache.set("test2", "epic2");
+    expect(await getGeneratorValues(cache.values())).toEqual(["epic1", "epic2"]);
+
+    // deleting keys should remove them from the result
+    await cache.delete("test1");
+    expect(await getGeneratorValues(cache.values())).toEqual(["epic2"]);
+
+    // clearing everything should mean an empty result
+    await cache.clear();
+    expect(await getGeneratorValues(cache.values())).toEqual([]);
+  });
+
+  it("should support null values", async () => {
+    const cache = new RedisMapCache<null>(client, "fortnite");
+
+    expect(await cache.get("test")).toBeUndefined();
+    await cache.set("test", null);
+    expect(await cache.get("test")).toBeNull();
+    expect(await cache.has("test")).toBeTruthy();
+    await cache.delete("test");
+    expect(await cache.get("test")).toBeUndefined();
   });
 });

--- a/src/redis/map.redis.test.ts
+++ b/src/redis/map.redis.test.ts
@@ -74,6 +74,16 @@ describe("RedisMapCache", () => {
     expect(await cache.keys()).toEqual([]);
   });
 
+  it("should support getting multiple keys", async () => {
+    const cache = new RedisMapCache<string>(client, "fortnite", { trackKeys: true });
+
+    await cache.set("test1", "epic");
+    await cache.set("test2", "epic");
+    await cache.set("test3", "epic");
+
+    expect(await cache.getMany(["test1", "test2", "test3"])).toEqual(["epic", "epic", "epic"]);
+  });
+
   it("should handle getting all entries in the cache", async () => {
     const cache = new RedisMapCache<string>(client, "fortnite", { trackKeys: true });
 
@@ -99,15 +109,15 @@ describe("RedisMapCache", () => {
 
     await cache.set("test1", "epic1");
     await cache.set("test2", "epic2");
-    expect(await getGeneratorValues(cache.values())).toEqual(["epic1", "epic2"]);
+    expect(await cache.values()).toEqual(["epic1", "epic2"]);
 
     // deleting keys should remove them from the result
     await cache.delete("test1");
-    expect(await getGeneratorValues(cache.values())).toEqual(["epic2"]);
+    expect(await cache.values()).toEqual(["epic2"]);
 
     // clearing everything should mean an empty result
     await cache.clear();
-    expect(await getGeneratorValues(cache.values())).toEqual([]);
+    expect(await cache.values()).toEqual([]);
   });
 
   it("should support null values", async () => {


### PR DESCRIPTION
Actually should have done this when I added keys() but I forgot. This adds `RedisMapCache.values()` to get all values in the cache and `RedisMapCache.entries()` to get all keys+values in the cache, basically the same as `Map.values()` and `Map.entries()`. At some point I think it would be cool if these were implemented in all caches but that sounds like a bit too much work and I'm lazy 😎

I ended up having to loosen up resolveRedisInstance() because it was causing tests to fail. In general I think typescript types should prevent people doing genuinely stupid stuff and it gets in the way in annoying scenarios with the strict "instanceof" check - for example, circular dependencies and certain setups can cause `instanceof` to fail for the exact same class. I think its purpose should be more "turn this into a redis instance" instead of "make sure this is a redis instance", as much as I want it to be strict and only allow the right things I think leaning on the side of "its probably fine" makes the library more usable in weird situations that I somehow keep getting myself into. I probably got a bit carried away but I couldn't get tests to pass without changing it, and I got a taste for blood. I also added tests for it. I'm not a huge fan of the `REDIS_CLASS_NAMES` thing but it works for now, I'm sure one day someone will come up with a stupidly simple way to do the exact same thing.

I also reverted [this commit](https://github.com/sylo-digital/kas/commit/44fac7520a1fba3604bfd9179f83a5341136e085) because that was intentional, it breaks the behaviour of `keys()` and is accounted for in `clear()` and `delete()`.